### PR TITLE
Update readme and point to Github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ const MyComponent = () => {
 export default MyComponent;
 ```
 
+Alternatively, you can do something with the `html` string directly.
+
+```jsx
+const { html } = useMarkdown(markdown);
+
+// Do something with the html string
+const newHtml = html + "<p>foo</p>";
+
+return <div dangerouslySetInnerHTML={{ __html: newHtml }} />;
+```
+
 ## Development
 
 Run in development environment.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nulib/use-markdown"
   }
 }


### PR DESCRIPTION
## What does this do?
- Create link to Github repo for NPM display
- Includes a quick example of how to use the `html` returned by the hook